### PR TITLE
Bump InfluxDB to 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 8086/tcp
 
 VOLUME /data
 
-ENV INFLUXDB_VERSION 1.2.1
+ENV INFLUXDB_VERSION 1.3.0
 
 RUN apt-get update -q -q && \
  apt-get --yes --force-yes install wget ca-certificates && \


### PR DESCRIPTION
Bump InfluxDB version to 1.3.0.
Valent found that they fixed a lot of issues and that memory leak should also be fixed